### PR TITLE
Added more useful WP_Error errors to dfrps_do_import_product_thumbnail() function

### DIFF
--- a/datafeedr-product-sets.php
+++ b/datafeedr-product-sets.php
@@ -7,8 +7,8 @@ Author: datafeedr.com
 Author URI: https://www.datafeedr.com
 License: GPL v3
 Requires at least: 3.8
-Tested up to: 5.7-alpha
-Version: 1.2.52
+Tested up to: 5.7-beta2
+Version: 1.2.53
 
 Datafeedr Product Sets Plugin
 Copyright (C) 2021, Datafeedr - help@datafeedr.com
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define constants.
  */
-define( 'DFRPS_VERSION', '1.2.52' );
+define( 'DFRPS_VERSION', '1.2.53' );
 define( 'DFRPS_DB_VERSION', '1.2.0' );
 define( 'DFRPS_SET_VERSION', '1.2.0' );
 define( 'DFRPS_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: datafeedr, product sets, dfrapi, dfrps, import csv, import datafeed, impor
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 3.8
-Tested up to: 5.7-alpha
-Stable tag: 1.2.52
+Tested up to: 5.7-beta2
+Stable tag: 1.2.53
 
 Build sets of products to import into your website.
 
@@ -79,6 +79,9 @@ Our support area can be found here: [https://datafeedrapi.helpscoutdocs.com/](ht
 6. Configuration: Advanced Update Settings
 
 == Changelog ==
+
+= 1.2.53 - 2021/02/12 =
+* Added more useful errors to `dfrps_do_import_product_thumbnail()` function.
 
 = 1.2.52 - 2021/02/10 =
 * Added `dfrps_error_log` function and added conditional check of `dfrps_log_errors` filter before logging.


### PR DESCRIPTION
Returns instance of `WP_Error` instead of false if image should not be imported.