### PR TITLE
Disabled image importing via add_action('the_post')

### DIFF
--- a/datafeedr-product-sets.php
+++ b/datafeedr-product-sets.php
@@ -113,7 +113,7 @@ function dfrps_import_image( $post ) {
 	new Dfrps_Image_Importer( $post );
 }
 
-add_action( 'the_post', 'dfrps_import_image' );
+//add_action( 'the_post', 'dfrps_import_image' );
 
 /**
  * Notify user that an Importer plugin is missing and is required.

--- a/functions/actions.php
+++ b/functions/actions.php
@@ -54,3 +54,60 @@ function dfrps_bulk_bump_priority_admin_notice() {
 }
 
 add_action( 'admin_notices', 'dfrps_bulk_bump_priority_admin_notice' );
+
+/**
+ * Schedule an image to be imported via the ActionScheduler plugin.
+ *
+ * @param array $post Array containing WordPress Post information.
+ * @param array $product Array containing Datafeedr Product information.
+ * @param array $set Array containing Product Set information.
+ * @param string $action Either "update" or "insert" depending on what the Product Set is doing.
+ */
+function dfrps_schedule_image_import( $post, $product, $set, $action ) {
+
+	if ( ! function_exists( 'dfrapi_schedule_async_action' ) ) {
+		dfrps_error_log( 'The dfrapi_schedule_async_action() function does not exist. Please upgrade your Datafeedr API plugin to the latest version.' );
+	}
+
+	$post_id = absint( $post['ID'] );
+
+	$do_import_thumbnail = dfrps_do_import_product_thumbnail( $post_id );
+
+	if ( is_wp_error( $do_import_thumbnail ) ) {
+		dfrps_error_log( 'Skipping image import' . ': ' . print_r( $do_import_thumbnail, true ) );
+
+		return;
+	}
+
+	dfrapi_schedule_async_action( 'import_product_image', compact( 'post_id' ), 'dfrps' );
+}
+
+add_action( 'dfrpswc_do_product', 'dfrps_schedule_image_import', 10, 4 );
+
+/**
+ * The action the ActionScheduler will call in order to import the image for $post_id.
+ *
+ * @param int $post_id
+ */
+function dfrps_import_product_image_action( $post_id ) {
+
+	if ( function_exists( 'datafeedr_import_image' ) ) {
+
+		$result = dfrps_import_post_thumbnail( $post_id );
+
+		if ( ! is_wp_error( $result ) && $result->has_error() ) {
+
+			$error = array(
+				'function' => __FUNCTION__,
+				'$url'     => $result->url(),
+				'$args'    => $result->args(),
+				'$post_id' => $post_id,
+				'WP_Error' => $result->wp_error(),
+			);
+
+			dfrps_error_log( 'Error importing image' . ': ' . print_r( $error, true ) );
+		}
+	}
+}
+
+add_action( 'dfrapi_as_import_product_image', 'dfrps_import_product_image_action' );

--- a/functions/helper.php
+++ b/functions/helper.php
@@ -811,10 +811,21 @@ function dfrps_do_import_product_thumbnail( $post_id ) {
 	$post = get_post( $post_id );
 
 	/**
+	 * If post is of the type "attachment", return WP_Error.
+	 */
+	if ( $post->post_type == 'attachment' ) {
+		return new WP_Error(
+			'dfrps_cannot_import_attachment_of_attachment',
+			__( 'Invalid $post->post_type.', 'datafeedr-product-sets' ),
+			array( 'function' => __FUNCTION__, '$post' => $post )
+		);
+	}
+
+	/**
 	 * If $post already has a thumbnail, return WP_Error.
 	 */
 	if ( has_post_thumbnail( $post ) ) {
-		$thumbnail_id = absint( get_post_thumbnail_id( $post ) );
+		$thumbnail_id = absint( get_post_thumbnail_id( $post->ID ) );
 
 		return new WP_Error(
 			'dfrps_post_already_has_thumbnail',
@@ -917,6 +928,9 @@ function dfrps_import_post_thumbnail( $post_id ) {
 
 	$post = get_post( $post_id );
 
+	/**
+	 * If no $post found, return WP_Error.
+	 */
 	if ( ! $post ) {
 		return new WP_Error(
 			'dfrps_post_not_found',


### PR DESCRIPTION
This is a result of the issue with Yoast SEO 15.8: https://github.com/Yoast/wordpress-seo/issues/16668

Basically, when using `add_action('the_post')` to trigger an import, this caused Yoast SEO to also issue a call to get a post which resulted in an infinite loop of `add_action('the_post')` actions being called.

This new method relies on the ActionScheduler and also relies on Datafeedr API plugin 1.2.0 (or greater).