### PR TITLE
Do not show last updated if completed is 0.

### DIFF
--- a/classes/class-dfrps-cpt.php
+++ b/classes/class-dfrps-cpt.php
@@ -1140,11 +1140,19 @@ class Dfrps_Cpt {
 			// Is updating now or has never updated.
 			// Show values from '_dfrps_cpt_previous_update_info' meta field if exists.
 			$meta = ( isset( $meta['_dfrps_cpt_previous_update_info'][0] ) ) ? maybe_unserialize( $meta['_dfrps_cpt_previous_update_info'][0] ) : array();
+			$completed = $meta['_dfrps_cpt_last_update_time_completed'][0];
 		}
 
 		if ( !isset( $meta['_dfrps_cpt_last_update_time_completed'][0] ) ) {
 
 			echo __( 'This Product Set has never been imported.', 'datafeedr-product-sets' );
+
+		} elseif( $completed == 0 ) {
+			echo __( 'This Product Set has not finished importing products yet.', 'datafeedr-product-sets' );
+
+			if ( is_array( $update_errors ) && !empty( $update_errors ) ) {
+				echo dfrapi_output_api_error( $update_errors );
+			}
 
 		} else {
 


### PR DESCRIPTION
For #21 

The issue here is in `Dfrps_Cpt::last_update_status()`. The `$completed` variable would get set to the value in the  `_dfrps_cpt_last_update_time_completed` meta, but if that value is 0, then the `$meta` would be overwritten with the serialized array in `_dfrps_cpt_previous_update_info`.

In the case of a new Product Set that is currently updating the value of one or both meta can be zero: `_dfrps_cpt_last_update_time_started` and `_dfrps_cpt_last_update_time_completed`.

To solve this I reset the value of `$completed` if the `$meta` is reset with the last updated info array.

Then if the array key is not set the text displayed is "This Product Set has never been imported."

If the array key exists, but completed is 0, the text displayed is "This Product Set has not finished importing products yet."

The Last Update meta box will not display, and the customer can see the progress of the import in the Dashboard meta box.

<img width="1294" alt="Screen Shot 2023-02-17 at 10 07 35 AM" src="https://user-images.githubusercontent.com/290886/219713790-7baedfdf-ca96-49df-9f75-0074c5ef5198.png">
Note: this screenshot was taken before I added the phrase "finished importing". 

## Showing for API Error

While testing I created a search with poorly formed SQL and the API returned an error. Automatic updates were switched to Disabled and the Product Set did not update. The error can be seen on the All Product Sets list view, but on the Product Set page the error is hidden if the full Last Update table is not shown:

<img width="1353" alt="Product Set has error, but can't see it" src="https://user-images.githubusercontent.com/290886/219714254-9e5da6b7-4c58-4ce0-b911-500fc23cb724.png">

In order to show the error to the store manager while the product set is in the middle of it's first update I added a check for `$update_errors` after the "not finished importing" text.


